### PR TITLE
fix: correct module name reference in example outputs.tf files

### DIFF
--- a/examples/Commerical/shared_gallery_new_rg/outputs.tf
+++ b/examples/Commerical/shared_gallery_new_rg/outputs.tf
@@ -3,20 +3,20 @@
 
 output "shared_image_gallery" {
   description = "Azure Shared Image Gallery output object"
-  value       = module.mod_shared_image_gallery.shared_image_gallery
+  value       = module.mod_compute_image_gallery.shared_image_gallery
 }
 
 output "id" {
   description = "Azure Shared Image Gallery ID"
-  value       = module.mod_shared_image_gallery.shared_image_gallery.id
+  value       = module.mod_compute_image_gallery.shared_image_gallery.id
 }
 
 output "name" {
   description = "Azure Shared Image Gallery name"
-  value       = module.mod_shared_image_gallery.shared_image_gallery.name
+  value       = module.mod_compute_image_gallery.shared_image_gallery.name
 }
 
 output "shared_images_definitions" {
   description = "Azure Shared Images definitions"
-  value       = module.mod_shared_image_gallery.shared_image
+  value       = module.mod_compute_image_gallery.shared_image
 }

--- a/examples/Government/shared_gallery_new_rg/outputs.tf
+++ b/examples/Government/shared_gallery_new_rg/outputs.tf
@@ -3,20 +3,20 @@
 
 output "shared_image_gallery" {
   description = "Azure Shared Image Gallery output object"
-  value       = module.mod_shared_image_gallery.shared_image_gallery
+  value       = module.mod_compute_image_gallery.shared_image_gallery
 }
 
 output "id" {
   description = "Azure Shared Image Gallery ID"
-  value       = module.mod_shared_image_gallery.shared_image_gallery.id
+  value       = module.mod_compute_image_gallery.shared_image_gallery.id
 }
 
 output "name" {
   description = "Azure Shared Image Gallery name"
-  value       = module.mod_shared_image_gallery.shared_image_gallery.name
+  value       = module.mod_compute_image_gallery.shared_image_gallery.name
 }
 
 output "shared_images_definitions" {
   description = "Azure Shared Images definitions"
-  value       = module.mod_shared_image_gallery.shared_image
+  value       = module.mod_compute_image_gallery.shared_image
 }


### PR DESCRIPTION
## Summary
Fixes module name mismatch between `main.tf` and `outputs.tf` in example directories.

## Root Cause
`outputs.tf` in both Commercial and Government examples referenced `module.mod_shared_image_gallery`, but `main.tf` defines the module as `module "mod_compute_image_gallery"`. Terraform fails with an unknown module error when running `terraform plan`.

## Changes
- `examples/Commerical/shared_gallery_new_rg/outputs.tf`: 4 references updated
- `examples/Government/shared_gallery_new_rg/outputs.tf`: 4 references updated

Fixes #6