### PR TITLE
fix: correct truncated module source slugs (tf-az-overlays → terraform-az-overlays)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,10 +1,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: tf-az-overlays-computeimagegallery
+  name: terraform-az-overlays-computeimagegallery
   description: Terraform overlay module for Azure Compute Image Gallery
   annotations:
-    github.com/project-slug: POps-Rox/tf-az-overlays-computeimagegallery
+    github.com/project-slug: POps-Rox/terraform-az-overlays-computeimagegallery
     backstage.io/techdocs-ref: dir:.
   tags:
     - terraform
@@ -12,7 +12,7 @@ metadata:
     - azure
     - platform-ops
   links:
-    - url: https://github.com/POps-Rox/tf-az-overlays-computeimagegallery
+    - url: https://github.com/POps-Rox/terraform-az-overlays-computeimagegallery
       title: GitHub Repository
       icon: github
 spec:

--- a/examples/Commerical/shared_gallery_new_rg/main.tf
+++ b/examples/Commerical/shared_gallery_new_rg/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_compute_image_gallery" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-computeimagegallery"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-computeimagegallery"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Government/shared_gallery_new_rg/main.tf
+++ b/examples/Government/shared_gallery_new_rg/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_compute_image_gallery" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-computeimagegallery"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-computeimagegallery"
   #version = "x.x.x"
   source = "../../.."
 

--- a/modules.compute.gallery.scaffolding.tf
+++ b/modules.compute.gallery.scaffolding.tf
@@ -6,7 +6,7 @@
 #--------------------------------------
 # This module will lookup the Azure Region and return the short name for the region
 module "mod_azregions" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = var.location
 }
@@ -23,7 +23,7 @@ data "azurerm_resource_group" "rg" {
 }
 
 module "mod_scaffold_rg" {
-  source = "github.com/POps-Rox/tf-az-overlays-resourcegroup"
+  source = "github.com/POps-Rox/terraform-az-overlays-resourcegroup"
 
   count = var.create_gallery_resource_group ? 1 : 0
 


### PR DESCRIPTION
## Summary
GitHub renamed these repos from `tf-az-overlays-*` to `terraform-az-overlays-*` in a prior cleanup, but module `source =` references in `.tf` files and `catalog-info.yaml` annotations still use the old slug. Terraform module downloads currently succeed only via GitHub's 301 redirect — fragile and prone to break.

## Changes
- All `.tf` files: `POps-Rox/tf-az-overlays-*` → `POps-Rox/terraform-az-overlays-*`
- All `.tf` files: `POps-Rox/tf-az-entra-overlays-*` → `POps-Rox/terraform-az-entra-overlays-*`
- `catalog-info.yaml`: `metadata.name` and `github.com/project-slug` annotation updated to match actual repo name

## Validation
```bash
grep -rln 'POps-Rox/tf-az-overlays\|pops-rox/tf-az-overlays' --include='*.tf' .
grep -l 'tf-az-overlays\|tf-az-entra-overlays' catalog-info.yaml
```
Both return no output after this PR.

Part of the POps-Rox Go-To-Market initiative.