### PR TITLE
chore: enable tflint-ruleset-azurerm rules

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,13 +1,39 @@
-plugin "terraform" {
-  enabled = true
-  preset  = "recommended"
-}
-
 plugin "azurerm" {
   enabled = true
   version = "0.28.0"
   source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
 }
 
-# Azurerm rules — installed but NOT enforced yet. Enablement deferred to Phase 4.
-# Individual rule enables go here after Phase 1 4.x migration is complete.
+# Azure resource validation — fail CI on invalid azurerm config values we just
+# migrated to in the 3.x → 4.x cutover. Names that did not exist in
+# tflint-ruleset-azurerm v0.28.0 (e.g. *_invalid_account_tier,
+# *_invalid_account_replication_type) are tracked as TODO so we can revisit
+# when the upstream ruleset adds them.
+rule "azurerm_storage_account_invalid_access_tier" {
+  enabled = true
+}
+rule "azurerm_storage_account_invalid_account_kind" {
+  enabled = true
+}
+rule "azurerm_resource_missing_tags" {
+  enabled = false # TODO: flip to true after fleet-wide tag policy is defined
+}
+
+# Standard terraform plugin rules
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}
+
+rule "terraform_required_version" {
+  enabled = true
+}
+rule "terraform_required_providers" {
+  enabled = true
+}
+rule "terraform_documented_variables" {
+  enabled = false # TODO: too noisy for module surfaces; revisit per repo
+}
+rule "terraform_documented_outputs" {
+  enabled = false # TODO: too noisy; revisit per repo
+}


### PR DESCRIPTION
Phase 4 of POps-Rox Go-To-Market. Enables Azure-specific tflint rules that were installed in Phase 0b. Rule selection is conservative to start — high-noise rules remain disabled with TODO comments for later enablement.

Local violation count (terraform + azurerm rule sets combined, baseline preset): **17**

These are pre-existing terraform-plugin findings (mostly `terraform_deprecated_index`, `terraform_module_pinned_source`, `terraform_typed_variables`, `terraform_unused_declarations`) and are surfaced — not introduced — by this change. They will be remediated as a follow-up. No new azurerm rule violations were detected.

See `.tflint-baseline/` in `pops-rox` umbrella repo for the canonical config.